### PR TITLE
SystemUI: fix zen mode panel warning not showing

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/volume/ZenModePanel.java
+++ b/packages/SystemUI/src/com/android/systemui/volume/ZenModePanel.java
@@ -421,8 +421,13 @@ public class ZenModePanel extends LinearLayout {
             mZenIntroductionCustomize.setVisibility(zenImportant ? VISIBLE : GONE);
         }
         final String warning = computeAlarmWarningText(zenNone);
-        mZenAlarmWarning.setVisibility(warning != null ? VISIBLE : GONE);
+        final int oldVis = mZenAlarmWarning.getVisibility();
+        final int newVis = warning != null ? VISIBLE : GONE;
+        mZenAlarmWarning.setVisibility(newVis);
         mZenAlarmWarning.setText(warning);
+        if (newVis != oldVis) {
+            requestLayout();
+        }
     }
 
     private String computeAlarmWarningText(boolean zenNone) {


### PR DESCRIPTION
We need to request a relayout of the view so the panel has a chance to
pick up the new height and update to that size.

Ref: CYNGNOS-2063

Change-Id: I6fa95f7a5a72646e0a990b6ffbac51fffdcf5272
Signed-off-by: Roman Birg <roman@cyngn.com>
(cherry picked from commit 01a268587abfddd45751008e14dc09572569e4d6)