### PR TITLE
SystemUI: Hide system/notification when config changes on kg.

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -3836,6 +3836,10 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         if (mState == StatusBarState.KEYGUARD) {
             // this will make sure the keyguard is showing
             showKeyguard();
+            // make sure to hide the notification icon area and system iconography
+            // to avoid overlap (CYNGNOS-2253)
+            mIconController.hideNotificationIconArea(false);
+            mIconController.hideSystemIconArea(false);
         }
 
         // update mLastThemeChangeTime


### PR DESCRIPTION
  If a config change happens on the keyguard (specific to themes)
  the system decorators can end up in a state where both the system
  status bar container and the keyguard status bar container are
  drawn over the top of each other. Work around this by forcing
  the system status bar iconography to hide if the current state
  is KEYGUARD.

Change-Id: Ic4ca491024264b11d7c115c5c5ffb277c6656683
TICKET: CYNGNOS-2253