### PR TITLE
NullPointerException when starting VoiceInteractionManagerService

### DIFF
--- a/core/java/android/service/voice/VoiceInteractionServiceInfo.java
+++ b/core/java/android/service/voice/VoiceInteractionServiceInfo.java
@@ -58,6 +58,10 @@ public class VoiceInteractionServiceInfo {
     }
 
     public VoiceInteractionServiceInfo(PackageManager pm, ServiceInfo si) {
+        if (si == null) {
+            mParseError = "Service not available";
+            return;
+        }
         if (!Manifest.permission.BIND_VOICE_INTERACTION.equals(si.permission)) {
             mParseError = "Service does not require permission "
                     + Manifest.permission.BIND_VOICE_INTERACTION;


### PR DESCRIPTION
If an end user disables the package that implements support for
Voice Assist (Google App) and reboots, an NPE is thrown during boot,
which results in the device getting stuck at the boot animation.

Recovery is not possible without USB debugging enabled, leaving factory
reset/user data wipe as the only other option.

Change-Id: I9c161fff7f096deee13bf8e37d951e20898ae3ff