### PR TITLE
Themes: Update icon mapping on boot

### DIFF
--- a/services/core/java/com/android/server/pm/PackageManagerService.java
+++ b/services/core/java/com/android/server/pm/PackageManagerService.java
@@ -17877,6 +17877,8 @@ public class PackageManagerService extends IPackageManager.Stub {
         for (String themePkgName : themesToProcess) {
             processThemeResources(themePkgName);
         }
+
+        updateIconMapping(themeConfig.getIconPackPkgName());
     }
 
     private void createAndSetCustomResources() {


### PR DESCRIPTION
Ensure icon mappings are applied on boot, otherwise themed icons
will not be picked up until a theme change occurs.

Change-Id: Iacda02c11d946e6f779d20739a6b2b67f407d6ba
TICKET: CYNGNOS-2434