### PR TITLE
SysUI:SysUI: Clean up objects when recreating statusbar and reAdd Ico…

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/KeyguardIndicationController.java
@@ -156,6 +156,11 @@ public class KeyguardIndicationController {
         }
     }
 
+    public void cleanup() {
+        KeyguardUpdateMonitor.getInstance(mContext).removeCallback(mUpdateMonitor);
+        mContext.unregisterReceiver(mReceiver);
+    }
+
     private void updateIndication() {
         if (mVisible) {
             mTextView.switchIndication(computeIndication());

--- a/packages/SystemUI/src/com/android/systemui/statusbar/SignalClusterView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/SignalClusterView.java
@@ -147,9 +147,14 @@ public class SignalClusterView
 
     public void setSecurityController(SecurityController sc) {
         if (DEBUG) Log.d(TAG, "SecurityController=" + sc);
+        if (sc == null && mSC != null) {
+            mSC.removeCallback(this);
+        }
         mSC = sc;
-        mSC.addCallback(this);
-        mVpnVisible = mSC.isVpnEnabled();
+        if (mSC != null) {
+            mSC.addCallback(this);
+            mVpnVisible = mSC.isVpnEnabled();
+        }
     }
 
     @Override

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardStatusBarView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/KeyguardStatusBarView.java
@@ -110,6 +110,8 @@ public class KeyguardStatusBarView extends RelativeLayout {
         }
     };
 
+    private UserInfoController mUserInfoController;
+
     public KeyguardStatusBarView(Context context, AttributeSet attrs) {
         super(context, attrs);
         showStatusBarCarrier();
@@ -150,6 +152,14 @@ public class KeyguardStatusBarView extends RelativeLayout {
         mCarrierLabel.setTextSize(TypedValue.COMPLEX_UNIT_PX,
                 getResources().getDimensionPixelSize(
                         com.android.internal.R.dimen.text_size_small_material));
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        if (mUserInfoController != null) {
+            mUserInfoController.removeListener(mUserInfoChangedListener);
+        }
     }
 
     private void loadDimens() {
@@ -338,13 +348,17 @@ public class KeyguardStatusBarView extends RelativeLayout {
         mMultiUserSwitch.setUserSwitcherController(controller);
     }
 
+    private UserInfoController.OnUserInfoChangedListener mUserInfoChangedListener =
+            new UserInfoController.OnUserInfoChangedListener() {
+        @Override
+        public void onUserInfoChanged(String name, Drawable picture) {
+            mMultiUserAvatar.setImageDrawable(picture);
+        }
+    };
+
     public void setUserInfoController(UserInfoController userInfoController) {
-        userInfoController.addListener(new UserInfoController.OnUserInfoChangedListener() {
-            @Override
-            public void onUserInfoChanged(String name, Drawable picture) {
-                mMultiUserAvatar.setImageDrawable(picture);
-            }
-        });
+        mUserInfoController = userInfoController;
+        userInfoController.addListener(mUserInfoChangedListener);
     }
 
     public void setKeyguardUserSwitcher(KeyguardUserSwitcher keyguardUserSwitcher) {
@@ -480,8 +494,4 @@ public class KeyguardStatusBarView extends RelativeLayout {
 		}   
 	    }
 	}
-    @Override
-    public void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
-    }
 }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/NotificationPanelView.java
@@ -445,7 +445,6 @@ public class NotificationPanelView extends PanelView implements
         mClipper = new QSDetailClipper(mTaskManagerPanel);
         mClockView = (TextView) findViewById(R.id.clock_view);
         mScrollView = (ObservableScrollView) findViewById(R.id.scroll_view);
-        mScrollView.setListener(this);
         mScrollView.setFocusable(false);
         mReserveNotificationSpace = findViewById(R.id.reserve_notification_space);
         mNotificationContainerParent = (NotificationsQuickSettingsContainer)

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PanelBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PanelBar.java
@@ -146,6 +146,16 @@ public abstract class PanelBar extends FrameLayout {
         return result;
     }
 
+    @Override
+    protected void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+        for (PanelView pv : mPanels) {
+            pv.setBar(null);
+        }
+        mPanels.clear();
+        mPanelHolder.setBar(null);
+    }
+
     // called from PanelView when self-expanding, too
     public void startOpeningPanel(PanelView panel) {
         if (DEBUG) LOG("startOpeningPanel: " + panel);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -417,11 +417,9 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
     View mExpandedContents;
     TextView mNotificationPanelDebugText;
 
-
     private QSPanel mQSPanel;
 
     private QSTileHost mQSTileHost;
-
 
     // task manager
     private TaskManager mTaskManager;
@@ -1606,7 +1604,9 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
             mStatusBarWindowManager.setLiveLockscreenController(mLiveLockScreenController);
         }
 
-        mHeadsUpManager = new HeadsUpManager(context, mStatusBarWindow);
+        if (mHeadsUpManager == null) {
+            mHeadsUpManager = new HeadsUpManager(context, mStatusBarWindow);
+        }
         mHeadsUpManager.setBar(this);
         mHeadsUpManager.addListener(this);
         mHeadsUpManager.addListener(mNotificationPanel);
@@ -1636,7 +1636,10 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
             addAppCircleSidebar();
         }
 
-        mAssistManager = new AssistManager(this, context);    
+        if (mAssistManager == null) {
+            mAssistManager = new AssistManager(this, context);
+        }
+        
         if (mNavigationBarView == null) {
             mAssistManager.onConfigurationChanged();
         }
@@ -1727,11 +1730,17 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         // Background thread for any controllers that need it.
         mHandlerThread = new HandlerThread(TAG, Process.THREAD_PRIORITY_BACKGROUND);
         mHandlerThread.start();
-
+        
         // Other icons
+        if (mLocationController == null) {
             mLocationController = new LocationControllerImpl(mContext,
                     mHandlerThread.getLooper()); // will post a notification
+        }
+        
+        if (mBatteryManager == null) {
             mBatteryManager = (BatteryManager) mContext.getSystemService(Context.BATTERY_SERVICE);
+        }
+        if (mBatteryController == null) {
             mBatteryController = new BatteryController(mContext, mHandler);
             mBatteryController.addStateChangedCallback(new BatteryStateChangeCallback() {
                 @Override
@@ -1753,27 +1762,42 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
                     // noop
                 }
             });
+        }    
         if (mBatteryManager.isDockBatterySupported()) {
             if (mDockBatteryController == null) {
                 mDockBatteryController = new DockBatteryController(mContext, mHandler);
             }
-        }
+	}
+        if (mNetworkController == null) {
             mNetworkController = new NetworkControllerImpl(mContext, mHandlerThread.getLooper());
+        }
+        if (mHotspotController == null) {
             mHotspotController = new HotspotControllerImpl(mContext);
+        }
+        if (mBluetoothController == null) {
             mBluetoothController = new BluetoothControllerImpl(mContext,
                     mHandlerThread.getLooper());
-            mSecurityController = new SecurityControllerImpl(mContext);
-        if (mContext.getResources().getBoolean(R.bool.config_showRotationLock)) {
-                mRotationLockController = new RotationLockControllerImpl(mContext);
         }
+        if (mSecurityController == null) {
+            mSecurityController = new SecurityControllerImpl(mContext);
+        }
+        if (mContext.getResources().getBoolean(R.bool.config_showRotationLock)) {
+            if (mRotationLockController == null) {
+                mRotationLockController = new RotationLockControllerImpl(mContext);
+            }
+        }
+        if (mUserInfoController == null) {
             mUserInfoController = new UserInfoController(mContext);
+        }
         mVolumeComponent = getComponent(VolumeComponent.class);
         if (mVolumeComponent != null) {
             if (mZenModeController == null) {
                 mZenModeController = mVolumeComponent.getZenController();
             }
         }
+        if (mCastController == null) {
             mCastController = new CastControllerImpl(mContext);
+        }
         if (mSuController == null) {
             mSuController = new SuControllerImpl(mContext);
         }
@@ -1796,17 +1820,34 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         if (isAPhone) {
             mNetworkController.addEmergencyListener(mHeader);
         }
-        mFlashlightController = new FlashlightController(mContext);
+
+        if (mFlashlightController == null) {
+            mFlashlightController = new FlashlightController(mContext);
+        }
         mKeyguardBottomArea.setFlashlightController(mFlashlightController);
         mKeyguardBottomArea.setPhoneStatusBar(this);
         mKeyguardBottomArea.setUserSetupComplete(mUserSetup);
-        mAccessibilityController = new AccessibilityController(mContext);
+        if (mAccessibilityController == null) {
+            mAccessibilityController = new AccessibilityController(mContext);
+        }
         mKeyguardBottomArea.setAccessibilityController(mAccessibilityController);
-        mNextAlarmController = new NextAlarmController(mContext);
-        mKeyguardMonitor = new KeyguardMonitor(mContext);
+        if (mNextAlarmController == null) {
+            mNextAlarmController = new NextAlarmController(mContext);
+        }
+        if (mKeyguardMonitor == null) {
+            mKeyguardMonitor = new KeyguardMonitor(mContext);
+        }
         if (UserSwitcherController.isUserSwitcherAvailable(UserManager.get(mContext))) {
+            if (mUserSwitcherController == null) {
                 mUserSwitcherController = new UserSwitcherController(mContext, mKeyguardMonitor,
                         mHandler);
+            }
+        }
+        mKeyguardUserSwitcher = new KeyguardUserSwitcher(mContext,
+                (ViewStub) mStatusBarWindowContent.findViewById(R.id.keyguard_user_switcher),
+                mKeyguardStatusBar, mNotificationPanel, mUserSwitcherController);
+        if (mWeatherController == null) {
+            mWeatherController = new WeatherControllerImpl(mContext);
         }
 
         mWeatherTempStyle = Settings.System.getIntForUser(
@@ -1974,8 +2015,7 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
                 (ViewStub) mStatusBarWindowContent.findViewById(R.id.keyguard_user_switcher),
                 mKeyguardStatusBar, mNotificationPanel, mUserSwitcherController);
 
-
-        // Set up the quick settings tile panel
+         // Set up the quick settings tile panel
         mQSPanel = (QSPanel) mStatusBarWindowContent.findViewById(R.id.quick_settings_panel);
 	if (mQSPanel != null) {
             final QSTileHost qsh = new QSTileHost(mContext, this,
@@ -1994,7 +2034,6 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
                 }
             });
         }
-
 
         // Task manager
         mTaskManagerPanel =
@@ -4757,6 +4796,10 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
         networkController.removeSignalCallback(signalCluster);
         networkController.removeSignalCallback(signalClusterKeyguard);
         networkController.removeSignalCallback(signalClusterQs);
+
+        if (signalCluster != null) signalCluster.setSecurityController(null);
+        if (signalClusterKeyguard != null) signalClusterKeyguard.setSecurityController(null);
+        if (signalClusterQs != null) signalClusterQs.setSecurityController(null);
     }
 
     private void recreateStatusBar() {
@@ -4764,9 +4807,22 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
 
         if (mNetworkController != null) {
             removeSignalCallbacks(mNetworkController);
+            if (mNetworkController.hasVoiceCallingFeature()) {
+                mNetworkController.removeEmergencyListener(mHeader);
+            }
         }
         if (mLiveLockScreenController != null) {
             mLiveLockScreenController.cleanup();
+        }    
+        if (mHeadsUpManager != null) {
+            mHeadsUpManager.removeListener(mNotificationPanel);
+            mHeadsUpManager.removeListener(mScrimController);
+        }
+        if (mIconController != null) {
+            mIconController.cleanup();
+        }
+        if (mKeyguardIndicationController != null) {
+            mKeyguardIndicationController.cleanup();
         }
 
         mKeyguardBottomArea.cleanup();
@@ -4782,17 +4838,20 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
             StatusBarIconView iconView = (StatusBarIconView) statusIcons.getChildAt(i);
             icons.add(iconView.getStatusBarIcon());
             iconSlots.add(iconView.getStatusBarSlot());
-        }	
+        }
+
         removeAllViews(mStatusBarWindowContent);
 
         // extract notifications.
         RankingMap rankingMap = mNotificationData.getRankingMap();
         int nNotifs = mNotificationData.size();
-        ArrayList<Pair<String, StatusBarNotification>> notifications =
-                new ArrayList<Pair<String, StatusBarNotification>>(nNotifs);
+        ArrayList<Pair<String, StatusBarNotification>> notifications = new ArrayList<>(nNotifs);
         copyNotifications(notifications, mNotificationData);
         // now remove all the notifications since we'll be re-creating these with the copied data
         mNotificationData.clear();
+
+        mQSPanel.setListening(false);
+
         makeStatusBarView();
         repositionNavigationBar();
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarIconController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/StatusBarIconController.java
@@ -701,6 +701,14 @@ public class StatusBarIconController implements Tunable {
         return mStatusIcons;
     }
 
+    public void cleanup() {
+        TunerService.get(mContext).removeTunable(this);
+        mClockController.cleanup();
+        if (mSignalCluster != null) {
+            mSignalCluster.setSecurityController(null);
+        }
+    }
+
     private void refreshAllIconsForLayout(LinearLayout ll) {
         final int count = ll.getChildCount();
         for (int n = 0; n < count; n++) {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/NetworkControllerImpl.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/NetworkControllerImpl.java
@@ -245,6 +245,10 @@ public class NetworkControllerImpl extends BroadcastReceiver
         mCallbackHandler.setEmergencyCallsOnly(isEmergencyOnly());
     }
 
+    public void removeEmergencyListener(EmergencyListener listener) {
+        mCallbackHandler.setListening(listener, false);
+    }
+
     public boolean hasMobileDataFeature() {
         return mHasMobileDataFeature;
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/UserInfoController.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/UserInfoController.java
@@ -74,6 +74,10 @@ public final class UserInfoController {
         mCallbacks.add(callback);
     }
 
+    public void removeListener (OnUserInfoChangedListener callback) {
+        mCallbacks.remove(callback);
+    }
+
     private final BroadcastReceiver mReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {


### PR DESCRIPTION
…ns()

Recreating the status bar for theme changes causes several views
and objects to not get GCed.  By analyzing hprof dumps of
com.android.systemui we can identify these issues and get things
properly cleaned up, and that's what this patch is doing.

RR Edits: This Was Mistakenly Removed During Dragpanel Revert
Add This Back to Fix a Small Mem Leak In System while recreating
This was Suspected to cause lag but now that we know the real cause , lets add this back

Orig Commits:
https://github.com/ResurrectionRemix/android_frameworks_base/commit/8c2eec14ef4541fb0b3df8d2b819718159d32527

https://github.com/ResurrectionRemix/android_frameworks_base/commit/02f0e1323e957c7ed3c22a80ac3fea1132557dc1

https://github.com/ResurrectionRemix/android_frameworks_base/commit/e4d5aa3a5f7fe93eab2fba5f655b7edb9dc8bc81