### PR TITLE
SystemUI: attach a queue to media player notifications

### DIFF
--- a/packages/SystemUI/AndroidManifest_cm.xml
+++ b/packages/SystemUI/AndroidManifest_cm.xml
@@ -20,6 +20,7 @@
         package="com.android.systemui">
 
     <uses-permission android:name="cyanogenmod.permission.WRITE_SECURE_SETTINGS" />
+    <uses-permission android:name="cyanogenmod.permission.WRITE_SETTINGS" />
 
     <!-- Visualizer -->
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />

--- a/packages/SystemUI/res/drawable/queue_bg.xml
+++ b/packages/SystemUI/res/drawable/queue_bg.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2015 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <ripple android:color="?android:colorControlHighlight">
+        <item android:state_pressed="true">
+            <shape android:shape="rectangle">
+                <solid android:color="@color/notification_ripple_untinted_color"/>
+            </shape>
+        </item>
+    </ripple>
+    <ripple android:color="?android:colorControlHighlight">
+        <item android:state_selected="true">
+            <shape android:shape="rectangle">
+                <solid android:color="@color/notification_ripple_untinted_color"/>
+            </shape>
+        </item>
+    </ripple>
+    <ripple android:color="?android:colorControlHighlight">
+        <item android:state_focused="true">
+            <shape android:shape="rectangle">
+                <solid android:color="@color/notification_ripple_untinted_color"/>
+            </shape>
+        </item>
+    </ripple>
+    <item>
+        <shape android:shape="rectangle">
+            <solid android:color="@color/notification_guts_bg_color"/>
+        </shape>
+    </item>
+</selector>

--- a/packages/SystemUI/res/drawable/queue_row_background.xml
+++ b/packages/SystemUI/res/drawable/queue_row_background.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2015 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<ripple xmlns:android="http://schemas.android.com/apk/res/android"
+        android:color="?android:attr/colorControlHighlight">
+    <item android:id="@+id/mask">
+        <color android:color="@color/system_secondary_color"/>
+    </item>
+</ripple>

--- a/packages/SystemUI/res/layout/notification_guts.xml
+++ b/packages/SystemUI/res/layout/notification_guts.xml
@@ -184,4 +184,14 @@
             android:layout_marginEnd="8dp"
             android:focusable="true"/>
     </LinearLayout>
+
+    <!-- Stub for the media extension guts -->
+    <ViewStub
+        android:layout="@layout/notification_guts_media_extension"
+        android:id="@+id/notification_guts_media_stub"
+        android:inflatedId="@+id/notification_guts_media_extension"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+
 </com.android.systemui.statusbar.NotificationGuts>

--- a/packages/SystemUI/res/layout/notification_guts_media_extension.xml
+++ b/packages/SystemUI/res/layout/notification_guts_media_extension.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2016, The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<com.android.systemui.statusbar.MediaNotificationGuts
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/notification_guts_media_extension"
+        android:padding="8dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="end"
+        android:orientation="horizontal">
+    <TextView
+            android:id="@+id/switch_label"
+            android:theme="@style/TextAppearance.NotificationGuts.Button"
+            android:layout_height="wrap_content"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:paddingEnd="8dp"
+            android:gravity="end"
+            android:text="@string/play_queue_extension"/>
+    <Switch
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="0"
+            android:theme="@style/ThemeOverlay.SwitchBar.Secondary"
+            android:paddingStart="8dp"
+            android:gravity="center"
+            android:id="@+id/queue_switch"/>
+</com.android.systemui.statusbar.MediaNotificationGuts>

--- a/packages/SystemUI/res/layout/queue_adapter_row.xml
+++ b/packages/SystemUI/res/layout/queue_adapter_row.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2015 The CyanogenMod Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<com.android.systemui.statusbar.QueueViewRow
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:background="@drawable/queue_bg"
+    android:layout_height="@dimen/queue_row_height"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp">
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:id="@+id/art"
+        android:layout_alignParentStart="true"
+        android:layout_centerVertical="true"/>
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toEndOf="@+id/action"
+        android:layout_centerVertical="true">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="@style/TextAppearance.NotificationGuts.Primary"
+            android:id="@+id/title"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="@style/TextAppearance.NotificationGuts.Header"
+            android:id="@+id/summary"/>
+    </LinearLayout>
+
+</com.android.systemui.statusbar.QueueViewRow>

--- a/packages/SystemUI/res/layout/status_bar_notification_row_media.xml
+++ b/packages/SystemUI/res/layout/status_bar_notification_row_media.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright 2014, The Android Open Source Project
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+
+<com.android.systemui.statusbar.MediaExpandableNotificationRow
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:focusable="true"
+    android:clickable="true"
+    >
+
+    <ViewStub
+        android:layout="@layout/notification_settings_icon_row"
+        android:id="@+id/settings_icon_row_stub"
+        android:inflatedId="@+id/notification_settings_icon_row"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        />
+
+    <com.android.systemui.statusbar.NotificationBackgroundView
+        android:id="@+id/backgroundNormal"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <com.android.systemui.statusbar.NotificationBackgroundView
+        android:id="@+id/backgroundDimmed"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:clipChildren="false"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:elevation="10dp">
+
+            <com.android.systemui.statusbar.NotificationContentView android:id="@+id/expanded"
+               android:layout_width="match_parent"
+               android:layout_height="wrap_content" />
+
+            <com.android.systemui.statusbar.NotificationContentView android:id="@+id/expandedPublic"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
+        </FrameLayout>
+
+        <com.android.systemui.statusbar.QueueView
+                android:id="@+id/queue_view"
+                android:clipChildren="false"
+                android:orientation="vertical"
+                android:background="@drawable/queue_bg"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:elevation="0dp">
+            <ListView
+                    android:id="@+id/queue_list"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"/>
+        </com.android.systemui.statusbar.QueueView>
+
+	</LinearLayout>
+
+    <Button
+        android:id="@+id/veto"
+        android:layout_width="48dp"
+        android:layout_height="0dp"
+        android:gravity="end"
+        android:layout_marginEnd="-80dp"
+        android:background="@null"
+        android:paddingEnd="8dp"
+        android:paddingStart="8dp"
+        />
+
+    <ViewStub
+        android:layout="@layout/notification_children_container"
+        android:id="@+id/child_container_stub"
+        android:inflatedId="@+id/notification_children_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+
+    <ViewStub
+        android:layout="@layout/notification_guts"
+        android:id="@+id/notification_guts_stub"
+        android:inflatedId="@+id/notification_guts"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        />
+
+    <com.android.systemui.statusbar.notification.FakeShadowView
+        android:id="@+id/fake_shadow"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</com.android.systemui.statusbar.MediaExpandableNotificationRow>

--- a/packages/SystemUI/res/values/cm_dimens.xml
+++ b/packages/SystemUI/res/values/cm_dimens.xml
@@ -23,4 +23,8 @@
     <dimen name="phone_bottom_padding">40dp</dimen>
     <dimen name="phone_width">320dp</dimen>
     <dimen name="phone_height">420dp</dimen>
+
+    <dimen name="queue_row_height">52dp</dimen>
+    <dimen name="queue_top_shadow">3dp</dimen>
+
 </resources>

--- a/packages/SystemUI/res/values/cm_strings.xml
+++ b/packages/SystemUI/res/values/cm_strings.xml
@@ -48,4 +48,8 @@
     <string name="select_application">Select application</string>
     <string name="lockscreen_choose_action_title">Choose action</string>
     <string name="lockscreen_none_target">None</string>
+
+    <!-- Play queue -->
+    <string name="play_queue_extension">Show play queue</string>
+
 </resources>

--- a/packages/SystemUI/res/values/styles.xml
+++ b/packages/SystemUI/res/values/styles.xml
@@ -369,4 +369,8 @@
         <item name="android:colorBackground">@color/qs_edit_overflow_bg</item>
     </style>
 
+    <style name="ThemeOverlay.SwitchBar.Secondary" parent="@android:style/ThemeOverlay">
+        <item name="android:colorAccent">@color/system_secondary_color</item>
+    </style>
+
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/ExpandHelper.java
+++ b/packages/SystemUI/src/com/android/systemui/ExpandHelper.java
@@ -34,6 +34,7 @@ import android.view.ViewConfiguration;
 import com.android.systemui.statusbar.ExpandableNotificationRow;
 import com.android.systemui.statusbar.ExpandableView;
 import com.android.systemui.statusbar.FlingAnimationUtils;
+import com.android.systemui.statusbar.MediaExpandableNotificationRow;
 import com.android.systemui.statusbar.policy.ScrollAdapter;
 
 public class ExpandHelper implements Gefingerpoken {
@@ -97,7 +98,7 @@ public class ExpandHelper implements Gefingerpoken {
     private float mCurrentHeight;
 
     private int mSmallSize;
-    private int mLargeSize;
+    private int mLargeSize, mInitialLargeSize;
     private float mMaximumStretch;
     private boolean mOnlyMovements;
 
@@ -162,6 +163,7 @@ public class ExpandHelper implements Gefingerpoken {
         mSmallSize = small;
         mMaximumStretch = mSmallSize * STRETCH_INTERVAL;
         mLargeSize = large;
+        mInitialLargeSize = large;
         mContext = context;
         mCallback = callback;
         mScaler = new ViewScaler();
@@ -515,8 +517,15 @@ public class ExpandHelper implements Gefingerpoken {
         boolean canBeExpanded = mCallback.canChildBeExpanded(v);
         if (canBeExpanded) {
             if (DEBUG) Log.d(TAG, "working on an expandable child");
-            mNaturalHeight = mScaler.getNaturalHeight();
             mSmallSize = v.getCollapsedHeight();
+            if (v instanceof MediaExpandableNotificationRow) {
+                final int maxHeight = ((MediaExpandableNotificationRow) v).getMaxContentHeight();
+                mLargeSize = maxHeight;
+                mNaturalHeight = maxHeight;
+            } else {
+                mLargeSize = mInitialLargeSize;
+                mNaturalHeight = mScaler.getNaturalHeight();
+            }
         } else {
             if (DEBUG) Log.d(TAG, "working on a non-expandable child");
             mNaturalHeight = mOldHeight;

--- a/packages/SystemUI/src/com/android/systemui/statusbar/BaseStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/BaseStatusBar.java
@@ -44,6 +44,7 @@ import android.database.ContentObserver;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.Icon;
+import android.media.session.MediaController;
 import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
@@ -906,6 +907,10 @@ public abstract class BaseStatusBar extends SystemUI implements
         return null;
     }
 
+    protected MediaController getCurrentMediaController() {
+        return null;
+    }
+
     @Override
     public NotificationGroupManager getGroupManager() {
         return mGroupManager;
@@ -1157,6 +1162,10 @@ public abstract class BaseStatusBar extends SystemUI implements
                 }
 
                 final ExpandableNotificationRow row = (ExpandableNotificationRow) v;
+                if (v instanceof MediaExpandableNotificationRow
+                        && !((MediaExpandableNotificationRow) v).inflateGuts()) {
+                    return false;
+                }
                 bindGuts(row);
 
                 // Assume we are a status_bar_notification_row
@@ -1618,8 +1627,20 @@ public abstract class BaseStatusBar extends SystemUI implements
             // create the row view
             LayoutInflater inflater = (LayoutInflater) mContext.getSystemService(
                     Context.LAYOUT_INFLATER_SERVICE);
-            row = (ExpandableNotificationRow) inflater.inflate(R.layout.status_bar_notification_row,
-                    parent, false);
+
+            // cannot use isMediaNotification()
+            if (sbn.getNotification().category != null
+                    && sbn.getNotification().category.equals(Notification.CATEGORY_TRANSPORT)) {
+                Log.d("ro", "inflating media notification");
+                row = (MediaExpandableNotificationRow) inflater.inflate(
+                        R.layout.status_bar_notification_row_media, parent, false);
+                ((MediaExpandableNotificationRow)row).setMediaController(
+                        getCurrentMediaController());
+            } else {
+                row = (ExpandableNotificationRow) inflater.inflate(
+                        R.layout.status_bar_notification_row,
+                        parent, false);
+            }
             row.setExpansionLogger(this, entry.notification.getKey());
             row.setGroupManager(mGroupManager);
             row.setHeadsUpManager(mHeadsUpManager);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/ExpandableNotificationRow.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/ExpandableNotificationRow.java
@@ -88,7 +88,7 @@ public class ExpandableNotificationRow extends ActivatableNotificationView {
     private boolean mSensitive;
     private boolean mSensitiveHiddenInGeneral;
     private boolean mShowingPublicInitialized;
-    private boolean mHideSensitiveForIntrinsicHeight;
+    protected boolean mHideSensitiveForIntrinsicHeight;
 
     /**
      * Is this notification expanded by the system. The expansion state can be overridden by the
@@ -103,10 +103,10 @@ public class ExpandableNotificationRow extends ActivatableNotificationView {
 
     private Animator mTranslateAnim;
     private ArrayList<View> mTranslateableViews;
-    private NotificationContentView mPublicLayout;
-    private NotificationContentView mPrivateLayout;
-    private int mMaxExpandHeight;
-    private int mHeadsUpHeight;
+    protected NotificationContentView mPublicLayout;
+    protected NotificationContentView mPrivateLayout;
+    protected int mMaxExpandHeight;
+    protected int mHeadsUpHeight;
     private View mVetoButton;
     private int mNotificationColor;
     private ExpansionLogger mLogger;
@@ -124,7 +124,7 @@ public class ExpandableNotificationRow extends ActivatableNotificationView {
     private boolean mIsSummaryWithChildren;
     private NotificationChildrenContainer mChildrenContainer;
     private ViewStub mSettingsIconRowStub;
-    private ViewStub mGutsStub;
+    protected ViewStub mGutsStub;
     private boolean mIsSystemChildExpanded;
     private boolean mIsPinned;
     private FalsingManager mFalsingManager;
@@ -1003,10 +1003,11 @@ public class ExpandableNotificationRow extends ActivatableNotificationView {
         return mSettingsIconRow;
     }
 
-    public void inflateGuts() {
+    public boolean inflateGuts() {
         if (mGuts == null) {
             mGutsStub.inflate();
         }
+        return false;
     }
 
     private void updateChildrenVisibility() {
@@ -1264,7 +1265,7 @@ public class ExpandableNotificationRow extends ActivatableNotificationView {
         }
     }
 
-    private void updateMaxHeights() {
+    protected void updateMaxHeights() {
         int intrinsicBefore = getIntrinsicHeight();
         View expandedChild = mPrivateLayout.getExpandedChild();
         if (expandedChild == null) {

--- a/packages/SystemUI/src/com/android/systemui/statusbar/ExpandableView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/ExpandableView.java
@@ -38,7 +38,7 @@ public abstract class ExpandableView extends FrameLayout {
     protected int mClipTopAmount;
     private boolean mDark;
     private ArrayList<View> mMatchParentViews = new ArrayList<View>();
-    private static Rect mClipRect = new Rect();
+    private Rect mClipRect = new Rect();
     private boolean mWillBeGone;
     private int mMinClipTopAmount = 0;
     private boolean mClipToActualHeight = true;

--- a/packages/SystemUI/src/com/android/systemui/statusbar/MediaExpandableNotificationRow.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/MediaExpandableNotificationRow.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2015 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package com.android.systemui.statusbar;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.media.session.MediaController;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.ViewStub;
+
+import com.android.systemui.R;
+import com.android.systemui.tuner.TunerService;
+
+public class MediaExpandableNotificationRow extends ExpandableNotificationRow
+        implements TunerService.Tunable {
+
+    private static final String TAG = MediaExpandableNotificationRow.class.getSimpleName();
+    public static final boolean DEBUG = false;
+
+    public static final int MAX_QUEUE_ENTRIES = 3;
+
+    private QueueView mQueue;
+
+    private int mMaxQueueHeight;
+    private int mRowHeight;
+    private int mShadowHeight;
+    private int mDisplayedRows;
+
+    private boolean mQueueEnabled = false;
+
+    private static final String NOTIFICATION_PLAY_QUEUE = "cmsystem:" +
+            cyanogenmod.providers.CMSettings.System.NOTIFICATION_PLAY_QUEUE;
+
+    public MediaExpandableNotificationRow(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        Resources res = mContext.getResources();
+
+        // 3 * queue_row_height + shadow height
+        mRowHeight = res.getDimensionPixelSize(R.dimen.queue_row_height);
+        mShadowHeight = res.getDimensionPixelSize(R.dimen.queue_top_shadow);
+    }
+
+    @Override
+    protected void onAttachedToWindow() {
+        super.onAttachedToWindow();
+        TunerService.get(getContext()).addTunable(this, NOTIFICATION_PLAY_QUEUE);
+    }
+
+    @Override
+    protected void onDetachedFromWindow() {
+        TunerService.get(getContext()).removeTunable(this);
+        super.onDetachedFromWindow();
+    }
+
+    @Override
+    public void onTuningChanged(String key, String newValue) {
+        if (NOTIFICATION_PLAY_QUEUE.equals(key) && mQueue != null) {
+            boolean show = newValue == null || Integer.valueOf(newValue) == 1;
+            showQueue(show);
+        }
+    }
+
+    @Override
+    public boolean inflateGuts() {
+        if (getGuts() == null) {
+            View guts = mGutsStub.inflate();
+            ViewStub mediaGuts = (ViewStub) guts.findViewById(R.id.notification_guts_media_stub);
+            mediaGuts.inflate();
+        }
+        if (!mQueueEnabled) {
+            return true;
+        }
+        return !mQueue.isUserSelectingRow();
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+        mQueue = (QueueView) findViewById(R.id.queue_view);
+        showQueue(mQueueEnabled);
+    }
+
+    private void showQueue(boolean show) {
+        if (show != mQueueEnabled) {
+            mQueueEnabled = show;
+            mQueue.setQueueEnabled(mQueueEnabled);
+            mQueue.setVisibility(mQueueEnabled ? View.VISIBLE : View.GONE);
+            requestLayout();
+        }
+    }
+
+    public void setMediaController(MediaController mediaController) {
+        if (DEBUG) Log.d(TAG, "setMediaController() called with "
+                + "mediaController = [" + mediaController + "]");
+        if (mQueue != null && mQueue.setController(mediaController) && mQueueEnabled) {
+            notifyHeightChanged(true);
+        }
+    }
+
+    @Override
+    protected void updateMaxHeights() {
+        // update queue height based on number of rows
+        int rows = mQueue != null ? mQueue.getCurrentQueueRowCount() : 0;
+        if (rows != mDisplayedRows) {
+            mMaxQueueHeight = rows * mRowHeight;
+            if (mMaxQueueHeight > 0) {
+                mMaxQueueHeight += mShadowHeight;
+            }
+            mDisplayedRows = rows;
+        }
+
+        int intrinsicBefore = getIntrinsicHeight();
+        View expandedChild = mPrivateLayout.getExpandedChild();
+        if (expandedChild == null) {
+            expandedChild = mPrivateLayout.getContractedChild();
+        }
+        mMaxExpandHeight = expandedChild.getHeight() + mMaxQueueHeight;
+        View headsUpChild = mPrivateLayout.getHeadsUpChild();
+        if (headsUpChild == null) {
+            headsUpChild = mPrivateLayout.getContractedChild();
+        }
+        mHeadsUpHeight = headsUpChild.getHeight();
+        if (intrinsicBefore != getIntrinsicHeight()) {
+            notifyHeightChanged(false  /* needsAnimation */);
+        }
+    }
+
+    @Override
+    public int getMaxContentHeight() {
+        return super.getMaxContentHeight() + mMaxQueueHeight;
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent event) {
+        if (mQueueEnabled && isExpanded() && mQueue.isUserSelectingRow()
+                && event.getActionMasked() != MotionEvent.ACTION_DOWN
+                && event.getActionMasked() != MotionEvent.ACTION_UP
+                && event.getActionMasked() != MotionEvent.ACTION_CANCEL) {
+            // this is for hotspot propogation?
+            return false;
+        }
+        return super.dispatchTouchEvent(event);
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/MediaNotificationGuts.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/MediaNotificationGuts.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2015 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+package com.android.systemui.statusbar;
+
+import android.content.Context;
+import android.graphics.Canvas;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.CompoundButton;
+import android.widget.LinearLayout;
+import android.widget.Switch;
+import android.widget.TextView;
+
+import com.android.systemui.R;
+
+import cyanogenmod.providers.CMSettings;
+
+/**
+ * The guts of a media notification revealed when performing a long press.
+ */
+public class MediaNotificationGuts extends LinearLayout {
+
+    private static final String TAG = MediaNotificationGuts.class.getSimpleName();
+
+    private ViewGroup mQueueGroup;
+    private TextView mText;
+    private Switch mSwitch;
+
+    public MediaNotificationGuts(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        setWillNotDraw(true);
+    }
+
+    @Override
+    protected void onDraw(Canvas canvas) {
+        // do nothing!
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+        mQueueGroup = (ViewGroup) findViewById(R.id.notification_guts_media_extension);
+
+        mSwitch = (Switch) findViewById(R.id.queue_switch);
+        boolean enabled = CMSettings.System.getInt(getContext().getContentResolver(),
+                CMSettings.System.NOTIFICATION_PLAY_QUEUE, 1) == 1;
+
+        mSwitch.setChecked(enabled);
+        mText = (TextView) findViewById(R.id.switch_label);
+        mText.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mSwitch.toggle();
+            }
+        });
+        mSwitch.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                buttonView.setChecked(isChecked);
+                CMSettings.System.putInt(getContext().getContentResolver(),
+                        CMSettings.System.NOTIFICATION_PLAY_QUEUE,
+                        isChecked ? 1 : 0);
+            }
+        });
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/NotificationGuts.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/NotificationGuts.java
@@ -58,9 +58,9 @@ public class NotificationGuts extends LinearLayout implements TunerService.Tunab
 
     private static final long CLOSE_GUTS_DELAY = 8000;
 
-    private Drawable mBackground;
-    private int mClipTopAmount;
-    private int mActualHeight;
+    protected Drawable mBackground;
+    protected int mClipTopAmount;
+    protected int mActualHeight;
     private boolean mExposed;
     private INotificationManager mINotificationManager;
     private int mStartingUserImportance;

--- a/packages/SystemUI/src/com/android/systemui/statusbar/QueueView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/QueueView.java
@@ -1,0 +1,254 @@
+/*
+ * Copyright (C) 2015 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package com.android.systemui.statusbar;
+
+import android.annotation.NonNull;
+import android.annotation.Nullable;
+import android.content.Context;
+import android.media.MediaDescription;
+import android.media.MediaMetadata;
+import android.media.session.MediaController;
+import android.media.session.MediaSession;
+import android.media.session.PlaybackState;
+import android.os.Handler;
+import android.provider.Settings;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.LinearLayout;
+import android.widget.ListView;
+import com.android.systemui.R;
+import com.android.systemui.cm.UserContentObserver;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QueueView extends LinearLayout implements
+        QueueViewRow.UserRowInteractionListener, AdapterView.OnItemClickListener,
+        AdapterView.OnItemLongClickListener {
+
+    private static final String TAG = QueueView.class.getSimpleName();
+    private static final boolean DEBUG = MediaExpandableNotificationRow.DEBUG;
+
+    private MediaController mController;
+
+    private List<MediaSession.QueueItem> mQueue = new ArrayList<>(getMaxQueueRowCount());
+
+    private QueueItemAdapter mAdapter;
+    private ListView mList;
+    private boolean mQueueEnabled;
+
+    long mLastUserInteraction = -1;
+
+    private MediaController.Callback mCallback = new MediaController.Callback() {
+        @Override
+        public void onPlaybackStateChanged(@NonNull PlaybackState state) {
+            super.onPlaybackStateChanged(state);
+
+            if (getParent() != null && updateQueue(mController.getQueue())) {
+                getParent().requestLayout();
+            }
+        }
+
+        @Override
+        public void onSessionDestroyed() {
+            if (DEBUG) Log.d(TAG, "onSessionDestroyed() called with " + "");
+            super.onSessionDestroyed();
+            setController(null);
+        }
+    };
+
+    public QueueView(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mAdapter = new QueueItemAdapter(context);
+        setClipToOutline(false);
+        setClipToPadding(false);
+    }
+
+    public void setQueueEnabled(boolean enabled) {
+        mQueueEnabled = enabled;
+        mAdapter.notifyDataSetChanged();
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+        mList = (ListView) findViewById(R.id.queue_list);
+        mList.setItemsCanFocus(true);
+        mList.setDrawSelectorOnTop(true);
+        mList.setChoiceMode(ListView.CHOICE_MODE_SINGLE);
+        mList.setAdapter(mAdapter);
+        mList.setOnItemLongClickListener(this);
+        mList.setOnItemClickListener(this);
+        mList.setVerticalScrollBarEnabled(false);
+    }
+
+    private class QueueItemAdapter extends ArrayAdapter<MediaSession.QueueItem> {
+
+        public QueueItemAdapter(Context context) {
+            super(context, R.layout.queue_adapter_row, mQueue);
+        }
+
+        @Override
+        public boolean hasStableIds() {
+            return true;
+        }
+
+        @Override
+        public long getItemId(int position) {
+            if (position > getCount() - 1) {
+                return -1;
+            }
+            return getItem(position).getQueueId();
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            final MediaSession.QueueItem queueItem = getItem(position);
+
+            if (convertView == null) {
+                convertView = LayoutInflater.from(parent.getContext())
+                        .inflate(R.layout.queue_adapter_row, parent, false);
+            }
+
+            QueueViewRow row = (QueueViewRow) convertView;
+            row.setHotSpotChangeListener(QueueView.this);
+
+            row.setQueueItem(queueItem);
+
+            return convertView;
+        }
+
+        @Override
+        public int getCount() {
+            if (!mQueueEnabled) {
+                return 0;
+            }
+            return super.getCount();
+        }
+    }
+
+    public boolean isUserSelectingRow() {
+        final long delta = System.currentTimeMillis() - mLastUserInteraction;
+        if (DEBUG) Log.i(TAG, "isUserSelectingRow() delta=" + delta);
+
+        if (mLastUserInteraction > 0 && delta < 500) {
+            if (DEBUG) Log.w(TAG, "user selecting row bc of hotspot change.");
+            return true;
+        }
+
+        return false;
+    }
+
+    public int getMaxQueueRowCount() {
+        return MediaExpandableNotificationRow.MAX_QUEUE_ENTRIES;
+    }
+
+    public int getCurrentQueueRowCount() {
+        if (mAdapter == null) {
+            return 0;
+        }
+        return mAdapter.getCount();
+    }
+
+    @Override
+    public void onHotSpotChanged(float x, float y) {
+        mLastUserInteraction = System.currentTimeMillis();
+    }
+
+    @Override
+    public void onDrawableStateChanged() {
+        mLastUserInteraction = System.currentTimeMillis();
+    }
+
+    /**
+     * @param queue
+     * @return whether the queue size has changed
+     */
+    public boolean updateQueue(List<MediaSession.QueueItem> queue) {
+        int queueSizeBefore = mAdapter.getCount();
+
+        mQueue.clear();
+
+        if (queue != null) {
+            // add everything *after* the currently playing item
+            boolean foundNowPlaying = false;
+
+            final PlaybackState playbackState = mController.getPlaybackState();
+
+            long activeQueueId = -1;
+            if (playbackState != null) {
+                activeQueueId = playbackState.getActiveQueueItemId();
+            }
+
+            for (int i = 0; i < queue.size() && mQueue.size() < getMaxQueueRowCount(); i++) {
+                final MediaSession.QueueItem item = queue.get(i);
+                if (!foundNowPlaying
+                        && activeQueueId != -1
+                        && activeQueueId == item.getQueueId()) {
+                    foundNowPlaying = true;
+                    continue;
+                }
+                if (foundNowPlaying) {
+                    mQueue.add(item);
+                }
+            }
+
+            // add everything
+            if (!foundNowPlaying) {
+                for(int i = 0; i < getMaxQueueRowCount() && i < queue.size(); i++) {
+                    mQueue.add(queue.get(i));
+                }
+            }
+        }
+        mAdapter.notifyDataSetChanged();
+
+        return mAdapter.getCount() != queueSizeBefore;
+    }
+
+    public boolean setController(MediaController controller) {
+        if (mController != null) {
+            mController.unregisterCallback(mCallback);
+        }
+        mController = controller;
+        if (mController != null) {
+            mController.registerCallback(mCallback);
+        }
+
+        return updateQueue(mController != null
+                ? mController.getQueue() : null);
+    }
+
+    @Override
+    public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        final MediaSession.QueueItem itemAtPosition = (MediaSession.QueueItem)
+                parent.getItemAtPosition(position);
+        if (itemAtPosition != null && mController != null) {
+            mController.getTransportControls().skipToQueueItem(itemAtPosition.getQueueId());
+        }
+        mAdapter.notifyDataSetChanged();
+    }
+
+    @Override
+    public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {
+        return true;
+    }
+
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/QueueViewRow.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/QueueViewRow.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2015 The CyanogenMod Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package com.android.systemui.statusbar;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.Paint;
+import android.media.MediaDescription;
+import android.media.session.MediaSession;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.RelativeLayout;
+import android.widget.TextView;
+import com.android.systemui.R;
+
+public class QueueViewRow extends RelativeLayout {
+
+    private static final String TAG = QueueViewRow.class.getSimpleName();
+
+    private UserRowInteractionListener mHotSpotChangeListener;
+
+    private ImageView mArt;
+    private TextView mTitle;
+    private TextView mSummary;
+
+    public QueueViewRow(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    protected void onFinishInflate() {
+        super.onFinishInflate();
+        mArt = (ImageView) findViewById(R.id.art);
+        mTitle = (TextView) findViewById(R.id.title);
+        mSummary = (TextView) findViewById(R.id.summary);
+    }
+
+    @Override
+    protected void drawableStateChanged() {
+        super.drawableStateChanged();
+        if (mHotSpotChangeListener != null) {
+            mHotSpotChangeListener.onDrawableStateChanged();
+        }
+    }
+
+    @Override
+    public void dispatchDrawableHotspotChanged(float x, float y) {
+        super.dispatchDrawableHotspotChanged(x, y);
+        if (mHotSpotChangeListener != null) {
+            mHotSpotChangeListener.onHotSpotChanged(x, y);
+        }
+    }
+
+    public void setHotSpotChangeListener(UserRowInteractionListener listener) {
+        mHotSpotChangeListener = listener;
+    }
+
+    public TextView getTitle() {
+        return mTitle;
+    }
+
+    public TextView getSummary() {
+        return mSummary;
+    }
+
+    public void setQueueItem(MediaSession.QueueItem queueItem) {
+        setTag(queueItem);
+
+        MediaDescription metadata = queueItem.getDescription();
+
+        final Bitmap bitmap = metadata.getIconBitmap();
+        mArt.setImageBitmap(bitmap);
+        mArt.setVisibility(bitmap != null ? View.VISIBLE : View.GONE);
+
+        mTitle.setText(metadata.getTitle());
+        mSummary.setText(metadata.getSubtitle());
+    }
+
+    /* package */ interface UserRowInteractionListener {
+        public void onHotSpotChanged(float x, float y);
+        public void onDrawableStateChanged();
+    }
+}

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -151,6 +151,7 @@ import com.android.systemui.statusbar.ExpandableNotificationRow;
 import com.android.systemui.statusbar.GestureRecorder;
 import com.android.systemui.statusbar.KeyboardShortcuts;
 import com.android.systemui.statusbar.KeyguardIndicationController;
+import com.android.systemui.statusbar.MediaExpandableNotificationRow;
 import com.android.systemui.statusbar.NotificationData;
 import com.android.systemui.statusbar.NotificationData.Entry;
 import com.android.systemui.statusbar.NotificationOverflowContainer;
@@ -2223,6 +2224,12 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
                     Log.v(TAG, "DEBUG_MEDIA: insert listener, receive metadata: "
                             + mMediaMetadata);
                 }
+                if (mediaNotification != null
+                        && mediaNotification.row != null
+                        && mediaNotification.row instanceof MediaExpandableNotificationRow) {
+                    ((MediaExpandableNotificationRow) mediaNotification.row)
+                            .setMediaController(controller);
+                }
 
                 if (mediaNotification != null) {
                     mMediaNotificationKey = mediaNotification.notification.getKey();
@@ -2634,6 +2641,11 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
     @Override  // NotificationData.Environment
     public String getCurrentMediaNotificationKey() {
         return mMediaNotificationKey;
+    }
+
+    @Override
+    protected MediaController getCurrentMediaController() {
+        return mMediaController;
     }
 
     public boolean isScrimSrcModeEnabled() {


### PR DESCRIPTION
Extend media player notificatoins to attach a queue below them, set via
the MediaController.setQueue() API, when available.

Long pressing on the notificaiton will reveal an option to disable the
queue.

The queue is currently hardcoded to be limited to 3 items.

(cyanogen: Port to CM14)

Ticket: CYNGNOS-217
Change-Id: I3b8503cb47af2d36f031d06aefc1bfbe7ed80010
Signed-off-by: Roman Birg <roman@cyngn.com>