### PR TITLE
StatusBarIconView: Enable notification icon count by default

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/StatusBarIconView.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/StatusBarIconView.java
@@ -113,7 +113,7 @@ public class StatusBarIconView extends AnimatedImageView {
     public void setNotification(Notification notification) {
         mNotification = notification;
         mShowNotificationCount = CMSettings.System.getIntForUser(mContext.getContentResolver(),
-                CMSettings.System.STATUS_BAR_NOTIF_COUNT, 0, UserHandle.USER_CURRENT) == 1;
+                CMSettings.System.STATUS_BAR_NOTIF_COUNT, 1, UserHandle.USER_CURRENT) == 1;
         setContentDescription(notification);
     }
 
@@ -450,7 +450,7 @@ public class StatusBarIconView extends AnimatedImageView {
 
         private void update() {
             boolean showIconCount = CMSettings.System.getIntForUser(mContext.getContentResolver(),
-                    CMSettings.System.STATUS_BAR_NOTIF_COUNT, 0, UserHandle.USER_CURRENT) == 1;
+                    CMSettings.System.STATUS_BAR_NOTIF_COUNT, 1, UserHandle.USER_CURRENT) == 1;
             for (StatusBarIconView sbiv : mIconViews) {
                 sbiv.mShowNotificationCount = showIconCount;
                 sbiv.set(sbiv.mIcon, true);


### PR DESCRIPTION
This used to be enabled by default in previous releases.

Change-Id: I24766bed58d081a0dd4763b9602379ff6435e092
(cherry picked from commit 4b4e8b379c8f57895fda5ee14528b72910dfb414)