### PR TITLE
Tethering: Fix number of device connected

### DIFF
--- a/services/core/java/com/android/server/connectivity/Tethering.java
+++ b/services/core/java/com/android/server/connectivity/Tethering.java
@@ -781,7 +781,12 @@ public class Tethering extends BaseNetworkObserver implements IControlsTethering
 
         if (mLastNotificationId != 0) {
             if (mLastNotificationId == icon) {
-                return;
+                if (!mContext.getResources().getBoolean(
+                        com.android.internal.R.bool.config_softap_extention)
+                        || icon != com.android.internal.R.drawable.stat_sys_tether_wifi) {
+                    // if softap extension feature is on, allow to update icon else return.
+                    return;
+                }
             }
             notificationManager.cancelAsUser(null, mLastNotificationId,
                     UserHandle.ALL);


### PR DESCRIPTION
The following commit prevents notification from being shown again when
notification is the same as previous one.

db3fe9edd4cb638d3dd20b23456f6cdb0a414ed1 Fix Tethering Notifications for
multiple ifaces

This is true except for the Wifi tethering which can have multiple
connections. Patch taken from cm12.1 code.

Change-Id: Ic30c6d3498595e2ba0561c709789fd6db1113f69