### PR TITLE
[2/3] Re-introduce custom charging on/off sounds

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/power/PowerUI.java
+++ b/packages/SystemUI/src/com/android/systemui/power/PowerUI.java
@@ -22,17 +22,23 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.database.ContentObserver;
+import android.media.Ringtone;
+import android.media.RingtoneManager;
+import android.net.Uri;
 import android.os.BatteryManager;
 import android.os.Handler;
 import android.os.PowerManager;
 import android.os.SystemClock;
 import android.os.UserHandle;
+import android.os.Vibrator;
 import android.provider.Settings;
 import android.util.Log;
 import android.util.Slog;
 
 import com.android.systemui.SystemUI;
 import com.android.systemui.statusbar.phone.PhoneStatusBar;
+
+import cyanogenmod.providers.CMSettings;
 
 import java.io.FileDescriptor;
 import java.io.PrintWriter;
@@ -56,6 +62,9 @@ public class PowerUI extends SystemUI {
     private final int[] mLowBatteryReminderLevels = new int[2];
 
     private long mScreenOffTime = -1;
+
+    // For filtering ACTION_POWER_DISCONNECTED on boot
+    private boolean mIgnoredFirstPowerBroadcast;
 
     public void start() {
         mPowerManager = (PowerManager) mContext.getSystemService(Context.POWER_SERVICE);
@@ -136,6 +145,8 @@ public class PowerUI extends SystemUI {
             filter.addAction(Intent.ACTION_USER_SWITCHED);
             filter.addAction(PowerManager.ACTION_POWER_SAVE_MODE_CHANGING);
             filter.addAction(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED);
+            filter.addAction(Intent.ACTION_POWER_CONNECTED);
+            filter.addAction(Intent.ACTION_POWER_DISCONNECTED);
             mContext.registerReceiver(this, filter, null, mHandler);
         }
 
@@ -155,6 +166,10 @@ public class PowerUI extends SystemUI {
 
                 final boolean plugged = mPlugType != 0;
                 final boolean oldPlugged = oldPlugType != 0;
+
+                if (!mIgnoredFirstPowerBroadcast && plugged) {
+                    mIgnoredFirstPowerBroadcast = true;
+                }
 
                 int oldBucket = findBatteryLevelBucket(oldBatteryLevel);
                 int bucket = findBatteryLevelBucket(mBatteryLevel);
@@ -203,11 +218,41 @@ public class PowerUI extends SystemUI {
                 mScreenOffTime = -1;
             } else if (Intent.ACTION_USER_SWITCHED.equals(action)) {
                 mWarnings.userSwitched();
+            } else if (Intent.ACTION_POWER_CONNECTED.equals(action)
+                    || Intent.ACTION_POWER_DISCONNECTED.equals(action)) {
+                if (mIgnoredFirstPowerBroadcast) {
+                    if (Settings.Global.getInt(mContext.getContentResolver(),
+                            Settings.Global.CHARGING_SOUNDS_ENABLED, 0) == 1) {
+                        playPowerNotificationSound();
+                    }
+                } else {
+                    mIgnoredFirstPowerBroadcast = true;
+                }
             } else {
                 Slog.w(TAG, "unknown intent: " + intent);
             }
         }
     };
+
+    private void playPowerNotificationSound() {
+        String soundPath = CMSettings.Global.getString(mContext.getContentResolver(),
+                CMSettings.Global.POWER_NOTIFICATIONS_RINGTONE);
+
+        if (soundPath != null && !soundPath.equals("silent")) {
+            Ringtone powerRingtone = RingtoneManager.getRingtone(mContext, Uri.parse(soundPath));
+            if (powerRingtone != null) {
+                powerRingtone.play();
+            }
+        }
+
+        if (CMSettings.Global.getInt(mContext.getContentResolver(),
+                CMSettings.Global.POWER_NOTIFICATIONS_VIBRATE, 0) == 1) {
+            Vibrator vibrator = (Vibrator) mContext.getSystemService(Context.VIBRATOR_SERVICE);
+            if (vibrator != null) {
+                vibrator.vibrate(250);
+            }
+        }
+    }
 
     public void dump(FileDescriptor fd, PrintWriter pw, String[] args) {
         pw.print("mLowBatteryAlertCloseLevel=");

--- a/services/core/java/com/android/server/power/Notifier.java
+++ b/services/core/java/com/android/server/power/Notifier.java
@@ -547,11 +547,6 @@ final class Notifier {
         if (DEBUG) {
             Slog.d(TAG, "onWirelessChargingStarted");
         }
-
-        mSuspendBlocker.acquire();
-        Message msg = mHandler.obtainMessage(MSG_WIRELESS_CHARGING_STARTED);
-        msg.setAsynchronous(true);
-        mHandler.sendMessage(msg);
     }
 
     private void updatePendingBroadcastLocked() {


### PR DESCRIPTION
PS2: some code tidying, remove unused imports
PS3: explicit check for silent ringtone.
     playing the ringtone "silent" actually
     makes noise on android 7.1.

Squash of:

Author: Sam Mortimer <sam@mortimer.me.uk>
Date:   Mon Mar 18 18:24:07 2013 -0700
    [1/2] Forward port power connect/disconnect notification support
    Original commit info:
        [1/2] Power connect/disconnect notification support
        part 1/2: frameworks/base PowerUI and Settings
        http://review.cyanogenmod.org/#/c/35241/
        part 2/2: packages/apps/Settings Sound settings
        http://review.cyanogenmod.org/#/c/35242/
        V-Old_Change-Id: I36a6b9f924d2cd52191a8e83a744745b37c5b068
        OldChange-Id: Ib865e1c296cb8e1d957b2a48616c88ceaba5c008
    Change-Id: I5db20ef23bdb644e2af06e8dcbc8fbd0cf7ce321

Author: Gianmarco Reverberi <gianmarco.reverberi@gmail.com>
Date:   Sun Nov 8 22:02:10 2015 +0100
    SystemUI: fix notification on charger
    Change-Id: I92382d556f6224f46beb211bfa0c4a22f2179683

Author: Michael Bestas <mikeioannina@cyanogenmod.org>
Date:   Wed Feb 10 02:50:12 2016 +0200
    SystemUI: Switch to AOSP CHARGING_SOUNDS_ENABLED
    Change-Id: Ia2fe8cbce18a505b7137f17657f35359a4c0bdb6

Author: Petr Sedlacek <petr@sedlacek.biz>
Date:   Fri Feb 6 21:55:30 2015 +0100
    Frameworks: follow charging notification settings also for wireless charging
    Originally, system would play a fixed notification sound when wireless
    charging starts from com.android.server.power.Notifier.java regardless
    of the Charging sounds settings. This removes the notification from
    Notifier.java which means the system will notify about wireless charging
    in the same (configurable) way as for normal wired charging.
    Change-Id: I034fc95f8ac3554ef1d463ac94bebd5a448e1a3f

Change-Id: I7c5654d55245ec7056bd1f0fdb88000ab09fc044