### PR TITLE
Revert "Frameworks: fix living wallpaper exception when reboot"

### DIFF
--- a/services/core/java/com/android/server/wallpaper/WallpaperManagerService.java
+++ b/services/core/java/com/android/server/wallpaper/WallpaperManagerService.java
@@ -1090,7 +1090,7 @@ public class WallpaperManagerService extends IWallpaperManager.Stub {
                     final WallpaperData fallback = new WallpaperData(wallpaper.userId,
                             WALLPAPER_LOCK_ORIG, WALLPAPER_LOCK_CROP);
                     ensureSaneWallpaperData(fallback);
-                    bindWallpaperComponentLocked(cname, true, false, fallback, reply);
+                    bindWallpaperComponentLocked(mImageWallpaper, true, false, fallback, reply);
                     mWaitingForUnlock = true;
                 }
             }


### PR DESCRIPTION
As highlighted by @razorloves, we currently have a 25s delay
during boot in WindowManager when a live wallpaper is configured.
Eventually, it gives up and forces display on anyway:
W WindowManager: ***** BOOT TIMEOUT: forcing display enabled

The original commit causes WallpaperManagerService to retry the
live wallpaper during boot instead of using a static fallback.
However, live wallpaper services aren't available at this
point so it causes WindowManagerService checkWaitingForWindowsLocked()
to return true owing to haveWallpaper never becoming true (during boot).
Hence, WindowManagerService performEnableScreen() will never
complete until a 30s timeout is hit and the screen is forced on
regardless of checkWaitingForWindowsLocked() state.

This reverts commit a770caaff633ae3f892d1795ae14811c9225ed94.

Original commit message:

Author: guangbing <guangbing@codeaurora.org>
Date:   Thu Sep 8 09:38:22 2016 +0800

    Frameworks: fix living wallpaper exception when reboot
    
    If living wallpaper is set, device shows static wallpaper
    for a moment after boot up then switches to living wallpaper.
    Bind service for getting wallpaper data will not success
    first time after reboot if the wallpaper isn't direct-boot
    aware,for getting the desired data requires the second
    parameter of bind method equals "MATCH_DIRECT_BOOT_UNAWARE",
    then rebind the service,and it shouldn't set first display
    as last setted static wallpaper before getting the desired
    data.
    
    As long as the boot time is set to show the living wallpaper
    first even if the wallpaper data is still in loading,it's
    better than show the static wallpaer first which would lead
    to the phenomenon of flash.
    
    Change-Id: Id3a75d44e25ee8744e0551bae046876880909650
    CRs-Fixed: 1056697


Change-Id: I3c13a85ab3b952e12353ecb0a6059bfe560a8c0f